### PR TITLE
Remove the unneeded "tabs" permission

### DIFF
--- a/src/chromium/__tests__/test-manifest.js
+++ b/src/chromium/__tests__/test-manifest.js
@@ -7,7 +7,7 @@ const manifest = require('../manifest.json')
 
 test('manifest permissions have not changed', () => {
   var permissions = manifest['permissions']
-  expect(permissions).toEqual(['tabs'])
+  expect(permissions).toEqual([])
 })
 
 test('content script permissions have not changed', () => {

--- a/src/chromium/manifest.json
+++ b/src/chromium/manifest.json
@@ -15,9 +15,7 @@
     "scripts": ["ext-background.js"],
     "persistent": false
   },
-  "permissions": [
-    "tabs"
-  ],
+  "permissions": [],
   "update_url": "http://clients2.google.com/service/update2/crx",
   "version": "5.19"
 }

--- a/src/firefox/__tests__/test-manifest.js
+++ b/src/firefox/__tests__/test-manifest.js
@@ -8,7 +8,7 @@ const manifestSelfHosted = require('../manifest.self-hosted-overrides.json')
 
 test('manifest permissions have not changed', () => {
   var permissions = manifest['permissions']
-  expect(permissions).toEqual(['tabs'])
+  expect(permissions).toEqual([])
 })
 
 test('content script permissions have not changed', () => {

--- a/src/firefox/manifest.json
+++ b/src/firefox/manifest.json
@@ -15,8 +15,6 @@
   "background": {
     "scripts": ["ext-background.js"]
   },
-  "permissions": [
-    "tabs"
-  ],
+  "permissions": [],
   "version": "5.11"
 }


### PR DESCRIPTION
We do not use the "tabs" permission. Removing it removes the permissions warning that the extension can "Read your browsing history".

The updated permissions will only say that the extension can "Replace the page you see when opening a new tab".