### PR TITLE
Update Firefox redirect to match Chrome extension behavior

### DIFF
--- a/src/firefox/newtab.html
+++ b/src/firefox/newtab.html
@@ -1,8 +1,10 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8"/>
-    <meta http-equiv="refresh" content="0;url=https://tab.gladly.io/newtab/" />
     <title>Tab for a Cause</title>
   </head>
-  <body></body>
+  <body>
+    <script type='text/javascript' src='./newtab.js'></script>
+  </body>
 </html>

--- a/src/firefox/newtab.js
+++ b/src/firefox/newtab.js
@@ -1,0 +1,15 @@
+/* globals browser */
+
+const NEW_TAB_URL = 'http://tab.gladly.io/newtab/'
+try {
+  browser.tabs.getCurrent((tab) => {
+    // The URL will not be highlighted, unfortunately, at least
+    // as of Firefox v91. See issues:
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1460412
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1409675
+    browser.tabs.update(tab.id, { url: NEW_TAB_URL })
+  })
+} catch (e) {
+  // Fall back to client-side navigation.
+  document.location.href = NEW_TAB_URL
+}


### PR DESCRIPTION
This PR makes Firefox's redirect match the more standard behavior of the Chrome extension and other new tab redirect extensions.

Firefox still does not support a highlighted URL with a remote new tab page, unfortunately. An iframed page, removed in #30 to respect policy around removing any remote code, is still the only functional approach for this.